### PR TITLE
fix: correct variable naming errors in EM class initialization

### DIFF
--- a/imputation/train_imputation_model.py
+++ b/imputation/train_imputation_model.py
@@ -193,7 +193,7 @@ class EM:
         self.discretizer = discretizer
         self.train_data = train_data
         self.eps = 1e-10
-        self.hist = {"train_likelihood": [], "val_likelihood": []}
+        self.hist = {"train_loglikelihood": [], "val_loglikelihood": []}
         self.initialize_parameters()
 
     def initialize_parameters(self):


### PR DESCRIPTION
- Renamed 'train_likelihood' and 'val_likelihood' to 'train_loglikelihood' and 'val_loglikelihood' in the hist dictionary to ensure consistent naming conventions.